### PR TITLE
Changing Some Functions Due Incompatibility

### DIFF
--- a/Source/SQLite3Utils.pas
+++ b/Source/SQLite3Utils.pas
@@ -55,13 +55,13 @@ var
 begin
   if Len < 0 then
   begin
-    Result := UTF8Decode(S);
+    Result := UTF8ToWideString(S);
   end
   else if Len > 0 then
   begin
     SetLength(UTF8Str, Len);
     Move(S^, UTF8Str[1], Len);
-    Result := UTF8Decode(UTF8Str);
+    Result := UTF8ToWideString(UTF8Str);
   end
   else Result := '';
 end;
@@ -85,7 +85,7 @@ begin
 {$IFDEF FPC}
   FS := DefaultFormatSettings;
 {$ELSE}
-  GetLocaleFormatSettings(GetThreadLocale, FS);
+  FS := TFormatSettings.Create(GetThreadLocale);
 {$ENDIF}
   FS.DecimalSeparator := '.';
   Result := FloatToStr(Value, FS);


### PR DESCRIPTION
UTF8Decode and GetFormatSettings don't have compatibility at Delphi. So, I change it to UTF8ToWideString that have the same parameter and return, and changed GetFormatSettings to the function TFormatSettings.Create